### PR TITLE
Remove duplicate line in Amul

### DIFF
--- a/Amul.m
+++ b/Amul.m
@@ -51,7 +51,6 @@ if ~isempty(dense.cols)
     if transp == 0
         y = y + dense.A*x(dense.cols);
     else
-        y = full(At*x);
         y(dense.cols) = dense.A'*x;
     end
 end


### PR DESCRIPTION
This line is already on line `48` so if `transp` is `1` and `dense.cols` is not empty, it is executed twice.