### PR TITLE
Added -obpath parameter to install_sedumi.m

### DIFF
--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -165,7 +165,7 @@ if need_rebuild,
     libs = {};
     
     if ~isempty(openblas_path)
-      if ~isdir(openblas_path)
+      if exist (openblas_path, "dir") ~= 7
         disp('Please set the correct OpenBLAS include path with');
         disp('  install_sedumi -obpath=/path/to/openblas/headers');
         disp('(the directory where the f77blas.h file is located).');

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -36,6 +36,13 @@ function install_sedumi( varargin )
 
 need_rebuild = any( strcmp( varargin, '-rebuild' ) );
 no_path = any( strcmp( varargin, '-nopath' ) );
+openblas_path = '';
+for v = 1:length(varargin)
+  [ob_S, ob_E, ob_TE, ob_M, ob_T, ob_NM, ob_SP] = regexp( varargin{v}, '-obpath=(?<path>.*)' );
+  if ~isempty(ob_NM.path)
+    openblas_path = ob_NM.path;
+  end
+end
 
 targets64={...
     'bwblkslv.c sdmauxFill.c sdmauxRdot.c',...
@@ -156,6 +163,16 @@ if need_rebuild,
     IS64BIT  = ~ISOCTAVE & strcmp(COMPUTER(end-1:end),'64');
     flags = {};
     libs = {};
+    
+    if ~isempty(openblas_path)
+      if ~isdir(openblas_path)
+        disp('OpenBLAS path not valid!');
+        break;
+      else
+        flags{end+1} = strcat('-I', openblas_path);
+      end
+    end
+    
     if ISOCTAVE,
         % Octave has mwSize and mwIndex hardcoded in mex.h as ints.
         % There is no definition for mwSignedIndex so include it here.  

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -39,7 +39,7 @@ no_path = any( strcmp( varargin, '-nopath' ) );
 openblas_path = '';
 for v = 1:length(varargin)
   [ob_S, ob_E, ob_TE, ob_M, ob_T, ob_NM, ob_SP] = regexp( varargin{v}, '-obpath=(?<path>.*)' );
-  if ~isempty(ob_NM.path)
+  if ~isempty(ob_NM) && ~isempty(ob_NM.path)
     openblas_path = ob_NM.path;
   end
 end

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -38,7 +38,7 @@ need_rebuild = any( strcmp( varargin, '-rebuild' ) );
 no_path = any( strcmp( varargin, '-nopath' ) );
 openblas_path = '';
 for v = 1:length(varargin)
-  [ob_S, ob_E, ob_TE, ob_M, ob_T, ob_NM, ob_SP] = regexp( varargin{v}, '-obpath=(?<path>.*)' );
+  ob_NM = regexp( varargin{v}, '-obpath=(?<path>.*)', 'names' );
   if ~isempty(ob_NM) && ~isempty(ob_NM.path)
     openblas_path = ob_NM.path;
   end

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -167,7 +167,7 @@ if need_rebuild,
     if ~isempty(openblas_path)
       if ~isdir(openblas_path)
         disp('OpenBLAS path not valid!');
-        break;
+        return;
       else
         flags{end+1} = strcat('-I', openblas_path);
       end

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -185,6 +185,10 @@ if need_rebuild,
         flags{end+1} = '-O';
         flags{end+1} = '-DOCTAVE';
         libs{end+1} = '-lblas';
+        
+        if isempty(openblas_path)
+          flags{end+1} = strcat('-I', '/usr/include/openblas');
+        end
     else
         flags{end+1} = '-O';
         if IS64BIT && ( VERSION >= 7.03 ),
@@ -244,6 +248,8 @@ if ~any(nfound),
     disp( line );
     disp( 'SeDuMi was not successfully installed.' );
     disp( 'Please attempt to correct the errors and try again.' );
+    disp( 'For example, try setting the OpenBLAS include path with' );
+    disp('  install_sedumi -obpath=/path/to/openblas/headers');
 elseif ~no_path,
     disp( line );
     fprintf( 'Adding SeDuMi to the %s path:\n', prog );

--- a/install_sedumi.m
+++ b/install_sedumi.m
@@ -166,7 +166,9 @@ if need_rebuild,
     
     if ~isempty(openblas_path)
       if ~isdir(openblas_path)
-        disp('OpenBLAS path not valid!');
+        disp('Please set the correct OpenBLAS include path with');
+        disp('  install_sedumi -obpath=/path/to/openblas/headers');
+        disp('(the directory where the f77blas.h file is located).');
         return;
       else
         flags{end+1} = strcat('-I', openblas_path);


### PR DESCRIPTION
The -obpath parameter can be used to manually supply a path to the OpenBLAS headers. Its usage is `install_sedumi -obpath=/path/to/openblas/headers` (e.g. `/usr/include/openblas`).