### PR TITLE
Typo in eigK

### DIFF
--- a/eigK.m
+++ b/eigK.m
@@ -75,7 +75,7 @@ end
 li = 0;
 xi = nf;
 lab = zeros(N,1);
-li(li+1:li+nl) = x(xi+1:xi+nl);
+lab(li+1:li+nl) = x(xi+1:xi+nl);
 xi = xi + nl;
 li = li + nl;
 if nq,


### PR DESCRIPTION
I think there's a typo in eigK.m in line 78:

li(li+1:li+nl) should be lab(li+1:lab+nl)

li is a counter, doesn't make sense for li to be indexed. Causes indexing errors in Matlab.

Jared