### PR TITLE
Add Travis CI for Linux Flatpak and Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,18 @@ jobs:
           update: true
       script: octave --eval "cd examples; test_sedumi(1, 1);"
     - os: linux
+      dist: bionic # 18.04 LTS, Octave 5.2.0 (flatpak)
+      before_install:
+      - sudo apt-get -y install flatpak
+      - flatpak remote-add --user --if-not-exists
+                flathub https://flathub.org/repo/flathub.flatpakrepo
+      - flatpak install --user -y flathub org.octave.Octave
+      addons:
+        apt:
+          update: true
+      script:
+      - flatpak run org.octave.Octave --eval "cd examples; test_sedumi(1, 1);"
+    - os: linux
       dist: bionic # 18.04 LTS, Octave 5.2.0 (snap)
       before_install:
       - sudo apt-get -y install snapd
@@ -37,3 +49,6 @@ jobs:
         homebrew:
           update: true
       script: octave --eval "cd examples; test_sedumi(1, 1);"
+    - os: windows
+      before_install: choco install octave.portable
+      script: octave-cli.exe --eval "cd examples; test_sedumi(1, 1);"


### PR DESCRIPTION
Does not work yet.

For MS Windows see:
- https://travis-ci.community/t/octave-fails-with-cannot-open-shared-object-file/2028
- https://www.scivision.dev/windows-matlab-octave-continuous-integration/