### PR TITLE
Add Travis CI for MS Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,6 @@ jobs:
       # https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/28
       osx_image: xcode12
       script: octave --eval "cd examples; test_sedumi(1, 1);"
+    - os: windows
+      before_install: choco install octave.portable
+      script: octave-cli.exe --eval "cd examples; test_sedumi(1, 1);"


### PR DESCRIPTION
Update of #56. Does not work yet.

For MS Windows see:

https://travis-ci.community/t/octave-fails-with-cannot-open-shared-object-file/2028
https://www.scivision.dev/windows-matlab-octave-continuous-integration/