### PR TITLE
Fix complex interface

### DIFF
--- a/pretransfo.m
+++ b/pretransfo.m
@@ -140,7 +140,7 @@ else
     if any(K.scomplex~=floor(K.scomplex)) || any(K.scomplex<1)
         error('K.scomplex should contain only positive integers');
     elseif any(K.scomplex>L_s)
-        error('Elements of K.xcomplex are out of range');
+        error('Elements of K.scomplex are out of range');
     end
 end
 if L_z
@@ -473,7 +473,7 @@ if K.rsdpN < length(K.s)
     imgv  = cols >= dsize;
     cols  = cols - imgv .* dsize;
     indxs = max(rows,cols) + min(rows,cols) .* dsize + imgv .* jsize(dblks) + istrt;
-    vals  = ( 1 - 2 * ( cols > rows ) ) .* ( 1 - ( 1 + 1j ) .* imgv );
+    vals = 1 + imgv .* (-1 + 1j * (1 - 2 * (rows > cols) ) );
     keep  = ~imgv | ( rows ~= cols );
     jndxs = rows + cols .* dsize + jstrt(dblks);
     ii{end+1} = indxs(keep);


### PR DESCRIPTION
As it is the complex interface is not working, it gives the wrong answer when we use the field K.scomplex. 

The problem is an error in the construction of the QR matrix: to compute 2*real(m(i,j)) it does m(i,j) - m(j,i) instead of m(i,j) + m(j,i). As such this only affects problems where the real part of the SDP coefficients are nonzero (which might be useful for testing). This PR fixes it. I'm happy to send code to demonstrate the issue, but I don't see how to attach a file to a PR.

I also fixed a typo in an error message that made me waste a lot of time with debugging.