### PR TITLE
remove pointless warning

### DIFF
--- a/maxeigK.m
+++ b/maxeigK.m
@@ -92,7 +92,7 @@ if ns
         XX = XX + XX';
         if ki > 500
             if nnz(XX) < 0.1 * numel(XX), XX = sparse(XX); end
-            [v,val,flag] = eigs(XX,1,'LA',struct('issym',true)); %#ok
+            [v,val,flag] = eigs(XX,1,'LA');
             if flag, val = max(eig(XX)); end
         else
             val = max(eig(XX));


### PR DESCRIPTION
It doesn't make sense to use `struct('issym',true))` here as `XX` is just a numerical matrix. It was causing pointless warnings.